### PR TITLE
Remove border 0 selector from bs4 filter in onet_scrape.py

### DIFF
--- a/onet_scrape.py
+++ b/onet_scrape.py
@@ -44,7 +44,7 @@ except:
 print("Response OK")
 print("Tabulating Jobs...")
 soup = BeautifulSoup(response.text, "html.parser")
-table = soup.find("table", border="0")
+table = soup.find("table")
 table2 = table.find_all("tr")
 
 columnNames = ["SOCcode", "JobName", "JobFamily", "isBright", "isGreen"]


### PR DESCRIPTION
The scraper was not finding the table with that selector, but simply removing it seemed to work. It looks like there may still be an issue with the willrobotstakemyjob.com scraping, but I just wanted the ONET.